### PR TITLE
Add media metadata viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore SQLite database file
+backend/mydatabase.db
+
+# Ignore uploads folder
+backend/uploads/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # Media-Metadata-Viewer
 Media Metadata Viewer
+
+## Project Description
+
+Media Metadata Viewer is a web application that allows users to upload media files and view their metadata. The application is built using Flask for the backend and plain HTML, CSS, and JavaScript for the frontend. The metadata is extracted using the `mutagen` library and stored in an SQLite database.
+
+## Setup Instructions
+
+### Prerequisites
+
+- Python 3.x
+- Flask
+- mutagen
+- SQLite
+
+### Installation
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/Tokenblkguy83/Media-Metadata-Viewer.git
+   cd Media-Metadata-Viewer
+   ```
+
+2. Set up a virtual environment and activate it:
+   ```
+   python -m venv venv
+   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+   ```
+
+3. Install the required packages:
+   ```
+   pip install Flask mutagen
+   ```
+
+4. Run the Flask application:
+   ```
+   cd backend
+   flask run
+   ```
+
+5. Open your web browser and go to `http://127.0.0.1:5000` to access the application.
+
+## Usage
+
+1. On the main page, use the file upload form to select a media file.
+2. Click the "Upload" button to upload the file.
+3. The metadata of the uploaded file will be displayed on the page.
+
+## Project Structure
+
+```
+Media-Metadata-Viewer/
+├── backend/
+│   ├── app.py         # Your Flask application
+│   ├── mydatabase.db  # Your SQLite database (might be ignored by git)
+│   └── uploads/       # Folder for uploaded media (should be ignored by git)
+├── frontend/
+│   ├── index.html     # Your main HTML file
+│   ├── css/
+│   │   └── style.css  # Your CSS file for the Matrix look
+│   └── js/
+│       └── script.js  # Your JavaScript file for frontend logic
+├── .gitignore         # File to tell Git what files/folders to ignore
+└── README.md          # Information about your project
+```
+
+## License
+
+This project is licensed under the MIT License.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,84 @@
+from flask import Flask, request, jsonify
+import sqlite3
+import os
+from werkzeug.utils import secure_filename
+from mutagen import File
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = 'uploads/'
+app.config['DATABASE'] = 'mydatabase.db'
+
+# Ensure the upload folder exists
+if not os.path.exists(app.config['UPLOAD_FOLDER']):
+    os.makedirs(app.config['UPLOAD_FOLDER'])
+
+# Initialize the database
+def init_db():
+    with sqlite3.connect(app.config['DATABASE']) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                metadata TEXT NOT NULL
+            )
+        ''')
+        conn.commit()
+
+init_db()
+
+# Function to save metadata to the database
+def save_metadata(filename, metadata):
+    with sqlite3.connect(app.config['DATABASE']) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            INSERT INTO metadata (filename, metadata)
+            VALUES (?, ?)
+        ''', (filename, metadata))
+        conn.commit()
+
+# Function to retrieve metadata from the database
+def get_metadata(filename):
+    with sqlite3.connect(app.config['DATABASE']) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT metadata FROM metadata
+            WHERE filename = ?
+        ''', (filename,))
+        result = cursor.fetchone()
+        return result[0] if result else None
+
+# Route to handle file uploads
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file part'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'No selected file'}), 400
+    if file:
+        filename = secure_filename(file.filename)
+        file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+        metadata = extract_metadata(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+        save_metadata(filename, metadata)
+        return jsonify({'message': 'File uploaded successfully', 'metadata': metadata}), 200
+
+# Function to extract metadata from a file
+def extract_metadata(filepath):
+    media_file = File(filepath)
+    metadata = {}
+    for key, value in media_file.tags.items():
+        metadata[key] = str(value)
+    return metadata
+
+# Route to retrieve metadata
+@app.route('/metadata/<filename>', methods=['GET'])
+def metadata(filename):
+    metadata = get_metadata(filename)
+    if metadata:
+        return jsonify({'metadata': metadata}), 200
+    else:
+        return jsonify({'error': 'Metadata not found'}), 404
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/backend/mydatabase.db
+++ b/backend/mydatabase.db
@@ -1,0 +1,1 @@
+SQLite format 3

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,0 +1,41 @@
+body {
+    background-color: black;
+    color: #00FF00;
+    font-family: 'Courier New', Courier, monospace;
+}
+
+h1 {
+    text-align: center;
+    font-size: 3em;
+    margin-top: 20px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 50px;
+}
+
+input[type="file"] {
+    margin-bottom: 20px;
+}
+
+button {
+    background-color: #00FF00;
+    color: black;
+    border: none;
+    padding: 10px 20px;
+    cursor: pointer;
+    font-size: 1em;
+}
+
+button:hover {
+    background-color: #00CC00;
+}
+
+#metadataDisplay {
+    margin-top: 50px;
+    text-align: center;
+    font-size: 1.2em;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Media Metadata Viewer</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <h1>Media Metadata Viewer</h1>
+    <form id="uploadForm" enctype="multipart/form-data">
+        <input type="file" id="fileInput" name="file">
+        <button type="submit">Upload</button>
+    </form>
+    <div id="metadataDisplay"></div>
+    <script src="js/script.js"></script>
+</body>
+</html>

--- a/frontend/js/script.js
+++ b/frontend/js/script.js
@@ -1,0 +1,27 @@
+document.getElementById('uploadForm').addEventListener('submit', function(event) {
+    event.preventDefault();
+    var formData = new FormData();
+    var fileInput = document.getElementById('fileInput');
+    formData.append('file', fileInput.files[0]);
+
+    fetch('/upload', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.error) {
+            alert(data.error);
+        } else {
+            displayMetadata(data.metadata);
+        }
+    })
+    .catch(error => {
+        console.error('Error:', error);
+    });
+});
+
+function displayMetadata(metadata) {
+    var metadataDisplay = document.getElementById('metadataDisplay');
+    metadataDisplay.innerHTML = '<pre>' + JSON.stringify(metadata, null, 2) + '</pre>';
+}


### PR DESCRIPTION
Add Flask application for file upload and metadata extraction, frontend for file upload and metadata display, and project setup instructions.

**Backend:**
* Add `backend/app.py` to set up Flask application, handle file uploads, extract metadata, and store/retrieve metadata in SQLite database.
* Add `backend/mydatabase.db` as SQLite database to store media metadata.

**Frontend:**
* Add `frontend/index.html` with HTML structure for file upload form and metadata display.
* Add `frontend/css/style.css` with CSS styles for the Matrix look.
* Add `frontend/js/script.js` with JavaScript logic to handle file uploads and display metadata.

**Project Configuration:**
* Add `.gitignore` to ignore `backend/mydatabase.db` and `backend/uploads/` folder.
* Update `README.md` with project description, setup instructions, usage, and project structure.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tokenblkguy83/Media-Metadata-Viewer/pull/3?shareId=e526605b-1bfc-4beb-bea6-cf6cf38853ad).

## Summary by Sourcery

Implement a media metadata viewer with a Flask backend and a plain HTML/CSS/JS frontend.

New Features:
- Add Flask backend to handle file uploads, extract media metadata using mutagen, and persist it in an SQLite database.
- Add frontend interface with file upload form and dynamic metadata display, styled with a Matrix-inspired CSS theme.

Documentation:
- Update README with project description, setup instructions, usage guide, and project structure.

Chores:
- Add .gitignore to exclude the SQLite database and uploads directory.
- Include initial SQLite database file as a placeholder.