### PR TITLE
Update Ci_backend.yml

### DIFF
--- a/.github/workflows/Ci_backend.yml
+++ b/.github/workflows/Ci_backend.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11.x'
 
       - name: Install Tesseract OCR Engine
         run: |

--- a/.github/workflows/Ci_backend.yml
+++ b/.github/workflows/Ci_backend.yml
@@ -3,10 +3,10 @@ name: Backend CI
 on:
   push:
     branches:
-      - main # Or master, depending on your main branch name
+      - main
   pull_request:
     branches:
-      - main # Or master
+      - main
 
 jobs:
   build:
@@ -15,50 +15,45 @@ jobs:
 
     steps:
       - name: Checkout Code
-        # Uses the actions/checkout@v4 action to download your repository code
         uses: actions/checkout@v4
 
       - name: Set up Python
-        # Uses the actions/setup-python@v5 action to set up a Python environment
         uses: actions/setup-python@v5
         with:
-          # Specify the Python version you want to use
-          python-version: '3.13' # Pinned to Python 3.10 for reproducibility
+          python-version: '3.11'
 
       - name: Install Tesseract OCR Engine
-        # Install the Tesseract OCR engine system-wide on the Ubuntu runner
-        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
+        run: |
+          sudo apt-get update || exit 1
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng || exit 1
 
       - name: Cache pip
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}-${{ matrix.python-version }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
       - name: Install Python Dependencies
-        # Navigate to the backend directory and install dependencies
         run: |
           cd backend
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Run basic app setup (creates DB and folders)
-        # Run the app.py file to initialize the SQLite database and folders
         run: |
           cd backend
           python app.py &
           sleep 5
           pkill -f "python app.py" || true
 
-      # Uncomment the following steps to enable linting and testing as part of the CI pipeline
-      # - name: Run Linting
-      #   run: |
-      #     cd backend
-      #     flake8 .
+      - name: Run Linting
+        run: |
+          cd backend
+          flake8 .
 
-      # - name: Run Tests
-      #   run: |
-      #     cd backend
-      #     pytest
+      - name: Run Tests
+        run: |
+          cd backend
+          pytest


### PR DESCRIPTION
## Summary by Sourcery

Update backend CI workflow to restrict triggers to the main branch, set Python to 3.11, improve caching and error handling, and enable linting and tests

CI:
- Restrict workflow triggers to only the main branch
- Upgrade Python setup from 3.13 to 3.11
- Include Python version in the pip cache key
- Add explicit exit handling to the Tesseract OCR installation step
- Enable linting and testing steps by uncommenting them